### PR TITLE
Get rid of double "yard" development_dependency

### DIFF
--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rake', "0.8.7"  if RUBY_VERSION == "1.9.2"
   s.add_runtime_dependency 'rake', ">= 0.9" if ["1.9.3", "1.8.7"].include?(RUBY_VERSION)
   s.add_development_dependency 'yard'
-  s.add_development_dependency 'yard'
   s.add_development_dependency 'rdiscount'
 
   s.required_ruby_version = '>= 1.8.7'


### PR DESCRIPTION
It does not work with `bundler v1.10.3`
